### PR TITLE
Prepare for changing repo name to example-bundles

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -1,6 +1,6 @@
 const { events, Job, Group } = require("brigadier")
 
-const projectName = "bundles"
+const projectName = "example-bundles"
 
 // minimal shell env for images w/o git, bash, etc.
 const shellEnv = {

--- a/openfaas/README.md
+++ b/openfaas/README.md
@@ -20,7 +20,7 @@ It demonstrates the following [CNAB Bundle](https://github.com/deislabs/cnab-spe
 
 - Clone this repo and `cd` into it.
 
-      git clone https://github.com/deislabs/bundles.git
+      git clone https://github.com/deislabs/example-bundles.git
       cd bundles/openfaas
 
 - Build the CNAB bundle with `duffle`


### PR DESCRIPTION
Besides the change suggested by @vdice, in `brigade.js`, the only other place where the repo name was mentioned was a readme for the OpenFaaS bundle.

This PR updates the repository to `deislabs/example-bundles`, as discussed during the community meeting and in Slack.

After this PR is approved and merged, we can actually update the repo name.